### PR TITLE
Added Async countdown strict mode.

### DIFF
--- a/src/main/java/io/vertx/ext/unit/Async.java
+++ b/src/main/java/io/vertx/ext/unit/Async.java
@@ -17,6 +17,8 @@ public interface Async extends Completion<Void> {
 
   /**
    * Count down the async.
+   *
+   * @throws IllegalStateException in strict mode if invoked more than the initial count
    */
   void countDown();
 

--- a/src/main/java/io/vertx/ext/unit/TestContext.java
+++ b/src/main/java/io/vertx/ext/unit/TestContext.java
@@ -1,7 +1,6 @@
 package io.vertx.ext.unit;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -255,6 +254,20 @@ public interface TestContext {
    * @return the async instance
    */
   Async async(int count);
+
+  /**
+   * Create and returns a new async object, the returned async controls the completion of the test.
+   * This async operation completes when the {@link Async#countDown()} is called {@code count} times.
+   * If {@link Async#countDown()} is called more than {@code count} times and {@code strict} is true, an {@link IllegalStateException} is thrown.<p/>
+   *
+   * The test case will complete when all the async objects have their {@link io.vertx.ext.unit.Async#complete()}
+   * method called at least once.<p/>
+   *
+   * This method shall be used for creating asynchronous exit points for the executed test.<p/>
+   *
+   * @return the async instance
+   */
+  Async async(int count, boolean strict);
 
   /**
    * Creates and returns a new async handler, the returned handler controls the completion of the test.<p/>

--- a/src/main/java/io/vertx/ext/unit/impl/TestContextImpl.java
+++ b/src/main/java/io/vertx/ext/unit/impl/TestContextImpl.java
@@ -81,10 +81,10 @@ public class TestContextImpl implements TestContext {
       return true;
     }
 
-    private AsyncImpl async(int count) {
+    private AsyncImpl async(int count, boolean strict) {
       synchronized (this) {
         if (!complete) {
-          AsyncImpl async = new AsyncImpl(count);
+          AsyncImpl async = new AsyncImpl(count, strict);
           if (failure == null) {
             asyncs.add(async);
           }
@@ -134,9 +134,11 @@ public class TestContextImpl implements TestContext {
 
       private final int initialCount;
       private final AtomicInteger current;
+      private final boolean strict;
 
-      public AsyncImpl(int initialCount) {
+      public AsyncImpl(int initialCount, boolean strict) {
         this.initialCount = initialCount;
+        this.strict = strict;
         this.current = new AtomicInteger(initialCount);
       }
 
@@ -147,8 +149,27 @@ public class TestContextImpl implements TestContext {
 
       @Override
       public void countDown() {
-        int value = current.updateAndGet(v -> v > 0 ? v - 1 : 0);
-        if (value == 0) {
+        int oldValue, newValue;
+        do {
+          oldValue = current.get();
+          if (oldValue == 0) {
+            newValue = 0;
+            if (strict) {
+              String msg;
+              if (initialCount == 1) {
+                msg = "Countdown invoked more than once";
+              } else if (initialCount == 2) {
+                msg = "Countdown invoked more than twice";
+              } else {
+                msg = "Countdown invoked more than " + initialCount + " times";
+              }
+              throw new IllegalStateException(msg);
+            }
+          } else {
+            newValue = oldValue - 1;
+          }
+        } while (!current.compareAndSet(oldValue, newValue));
+        if (newValue == 0) {
           completable.complete(null);
           internalComplete();
         }
@@ -238,12 +259,17 @@ public class TestContextImpl implements TestContext {
 
   @Override
   public Async async(int count) {
+    return async(count, false);
+  }
+
+  @Override
+  public Async async(int count, boolean strict) {
     if (count < 1) {
       throw new IllegalArgumentException("Async completion count must be > 0");
     }
     synchronized (this) {
       if (current != null) {
-        return current.async(count);
+        return current.async(count, strict);
       } else {
         throw new IllegalStateException();
       }

--- a/src/test/java/io/vertx/ext/unit/TestSuiteTestBase.java
+++ b/src/test/java/io/vertx/ext/unit/TestSuiteTestBase.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 /**
@@ -300,6 +301,27 @@ public abstract class TestSuiteTestBase {
     TestResult result = reporter.results.get(0);
     assertEquals("my_test", result.name());
     assertTrue(result.succeeded());
+  }
+
+  @Test
+  public void runTestWithStrictAsyncCountingDown() throws Exception {
+    TestSuite suite = TestSuite.create("my_suite").
+      test("my_test", context -> {
+        Async async = context.async(1, true);
+        async.countDown();
+        async.countDown();
+      });
+    TestReporter reporter = new TestReporter();
+    run(suite, reporter);
+    reporter.await();
+    assertTrue(reporter.completed());
+    assertEquals(0, reporter.exceptions.size());
+    assertEquals(1, reporter.results.size());
+    TestResult result = reporter.results.get(0);
+    assertEquals("my_test", result.name());
+    assertTrue(result.failed());
+    assertTrue(result.failure().isError());
+    assertThat(result.failure().cause(), instanceOf(IllegalStateException.class));
   }
 
   @Test


### PR DESCRIPTION
Fixes #60

In strict mode Async.countdown will throw an ISE if invoked more than the initial count.

Strict mode is disabled that default (existing code will not break).